### PR TITLE
remove unhandled import arguments

### DIFF
--- a/lib/Game/Tibia/Packet.pm
+++ b/lib/Game/Tibia/Packet.pm
@@ -6,7 +6,7 @@ package Game::Tibia::Packet;
 # ABSTRACT: Minimal session layer support for the MMORPG Tibia
 # VERSION
 
-use Digest::Adler32 qw(adler32);
+use Digest::Adler32;
 use Crypt::XTEA 0.0108;
 use Crypt::ECB 2.0.0;
 use Carp;


### PR DESCRIPTION
Previous versions of perl allow a use or import call even if the import method doesn't exist. Future versions are intending to throw errors for calls to an undefined import method that includes arguments.

Remove the arguments to use lines when the import method does not exist.